### PR TITLE
MAINT: gitignore and git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalise line endings for tex files
+
+*.tex text=auto eol=lf
+*.py text=auto eol=lf
+
+# Force git to look at some files as binary
+*.png binary
+*.pdf binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.synctex.gz
+*.aux
+*.log


### PR DESCRIPTION
It's normally a good idea to normalise line endings. This can be done via `.gitattributes`